### PR TITLE
feat: change CV download button label to Resume

### DIFF
--- a/content.json
+++ b/content.json
@@ -34,7 +34,7 @@
     "about": "About",
     "education": "Education",
     "experience": "Experience",
-    "downloadCv": "Download CV"
+    "downloadCv": "Download Resume"
   },
   "header": {
     "name": "Leandro Fernandez",

--- a/openspec/changes/issue-21-resume-button-label/design.md
+++ b/openspec/changes/issue-21-resume-button-label/design.md
@@ -1,0 +1,44 @@
+# Design: issue-21-resume-button-label
+
+## Technical Approach
+
+The overall strategy is to modify the localized string values in `content.json` while retaining the existing JSON keys. The site uses a simple Node.js template replacement script (`scripts/replace.js`) to parse `content.json` and replace `{{nav.downloadCv}}` placeholders in `index.html`. By editing `content.json` on line 37 to have the value "Download Resume", the build step will automatically populate `index.html` with the new button label.
+
+## Architecture Decisions
+
+### Decision: Update JSON Value vs Adding New Key
+
+**Choice**: Modify the value of the existing `nav.downloadCv` key to "Download Resume".
+**Alternatives considered**: Add a new key `nav.downloadResume` to `content.json` and change the reference in `index.html` to `{{nav.downloadResume}}`.
+**Rationale**: `downloadCv` acts as an internal identifier for the "download document" action within the site's data model. The label presented to the user is presentation data. Changing the key name adds unnecessary churn to both `content.json` and `index.html`. Changing only the value correctly updates the presentation without touching the template structure.
+
+## Data Flow
+
+Data flows from the JSON content file into the HTML template during the build step:
+
+    content.json ("Download Resume") ──→ replace.js ──→ index.html (Output)
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `content.json` | Modify | Update `nav.downloadCv` from "Download CV" to "Download Resume" |
+
+## Interfaces / Contracts
+
+No new interfaces or API contracts are being introduced. The structure of `content.json` remains identical.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Manual | Build Output | Run the build script and verify the resulting HTML contains "Download Resume" in the navigation button. |
+| Manual | Browser | Open the generated site in a browser and verify the button in the header visually reflects the new label and still triggers the `window.print()` action. |
+
+## Migration / Rollout
+
+No migration required. The change will be deployed alongside the next static build of the site.
+
+## Open Questions
+
+None

--- a/openspec/changes/issue-21-resume-button-label/proposal.md
+++ b/openspec/changes/issue-21-resume-button-label/proposal.md
@@ -1,0 +1,60 @@
+# Proposal: Issue 21 — Change CV download button label to 'Resume'
+
+## Intent
+
+The navbar button currently reads "Download CV" but should read "Download Resume". This aligns the label with industry-standard terminology ("Resume" over "CV") as requested in Issue 21.
+
+## Scope
+
+### In Scope
+- Change `content.json:37` — `"downloadCv": "Download CV"` → `"downloadCv": "Download Resume"`
+- Update delta spec for `static-cv-page` to correct 2 "Download CV" references (lines 11, 29) to "Download Resume"
+- Work in an isolated git worktree: `fix/issue-21-resume-button-label` from `main`
+
+### Out of Scope
+- Renaming the JSON key `downloadCv` (internal identifier, no user impact)
+- Changing other "CV" occurrences in `content.json` (browser title, OG, Twitter card)
+- Changing the button's `window.print()` behavior
+- Adding automated test coverage for the label text
+
+## Capabilities
+
+### New Capabilities
+- None
+
+### Modified Capabilities
+- `static-cv-page`: Navigation Bar requirement changes the button label from "Download CV" to "Download Resume". The 320px viewport scenario references the button by name and MUST be updated to match.
+
+## Approach
+
+Single-line text edit in `content.json`. The JSON key name `downloadCv` stays unchanged — it's an internal identifier consumed by `{{nav.downloadCv}}` in `index.html`. The build-time replacement (`scripts/replace.js`) resolves the key via dot notation, so only the value matters. No HTML, script, or structural changes required. A delta spec updates the two "Download CV" references in the Navigation Bar requirement to "Download Resume".
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `content.json:37` | Modified | Button label value `"Download CV"` → `"Download Resume"` |
+| `openspec/specs/static-cv-page/spec.md` | Modified (delta) | 2 references to "Download CV" updated to "Download Resume" |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Spec drift — main spec still says "Download CV" after deploy | High | Delta spec in this change corrects both references |
+| Key/value semantic mismatch (`downloadCv` key holds "Resume" value) | Low | Internal identifier, no user impact; rename deferred |
+| No test validates the label text | Low | One-word text change; E2E test framework exists if needed later |
+
+## Rollback Plan
+
+Revert `content.json:37` back to `"downloadCv": "Download CV"` with `git revert` or `git checkout main -- content.json`. The delta spec is reverted independently since it lives in the change folder.
+
+## Dependencies
+
+- Git worktree at `/home/leandro/projects/my-site-issue-21` branched from `main`
+
+## Success Criteria
+
+- [ ] Navbar button renders "Download Resume" in the browser after build
+- [ ] No `{{placeholder}}` strings remain in `dist/index.html`
+- [ ] Delta spec for `static-cv-page` references "Download Resume" (not "Download CV")
+- [ ] `npm run build` succeeds without errors

--- a/openspec/changes/issue-21-resume-button-label/specs/static-cv-page/spec.md
+++ b/openspec/changes/issue-21-resume-button-label/specs/static-cv-page/spec.md
@@ -1,0 +1,29 @@
+# Delta for static-cv-page
+
+## MODIFIED Requirements
+
+### Requirement: Navigation Bar
+
+The page MUST include a fixed `<nav>` element at the top of the viewport with glassmorphism styling (semi-transparent background with backdrop-blur). The navbar MUST contain anchor links to each section (#about, #education, #experience) and a "Download Resume" button. The navbar MUST remain fixed during scroll and MUST NOT overlap or clip page content below. The navbar MUST NOT cause horizontal overflow on any viewport between 320px and 1100px wide. All navbar content (links, buttons) MUST remain visible and tap-accessible without requiring horizontal scrolling. The navbar MUST use `display: none` via a `.no-print` class for print media.
+
+(Previously: navbar contained a "Download CV" button; label changed to "Download Resume")
+
+#### Scenario: Navbar links navigate to sections
+
+- GIVEN the page is loaded
+- WHEN the user clicks a section link in the navbar
+- THEN the viewport scrolls to the corresponding section
+
+#### Scenario: Navbar is hidden in print
+
+- GIVEN print media is active
+- WHEN the page renders for print
+- THEN the navbar is not visible
+
+#### Scenario: Navbar fits without horizontal scroll at 320px
+
+- GIVEN the page is loaded at viewport width 320px
+- WHEN the navbar renders
+- THEN all links and the Download Resume button are visible
+- AND no horizontal scrollbar appears on the page
+- AND all nav items remain tap-accessible (min 12px text)

--- a/openspec/changes/issue-21-resume-button-label/tasks.md
+++ b/openspec/changes/issue-21-resume-button-label/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: quiero que resuelvas el issue 21 en un worktree
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | < 10 lines |
+| 400-line budget risk | Low |
+| Chained PRs recommended | No |
+| Suggested split | single PR |
+| Delivery strategy | ask-always |
+| Chain strategy | size-exception |
+
+Decision needed before apply: No
+Chained PRs recommended: No
+Chain strategy: size-exception
+400-line budget risk: Low
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | Update resume button label | PR 1 | Single PR targeting main |
+
+## Phase 1: Setup
+
+- [x] 1.1 Create worktree using command: `git worktree add /home/leandro/projects/my-site-issue-21 -b fix/issue-21-resume-button-label main`
+- [x] 1.2 Navigate to the newly created worktree directory.
+
+## Phase 2: Core
+
+- [x] 2.1 Modify `content.json` to change the value of the `downloadCv` key from "Download CV" to "Download Resume" (or equivalent instances mentioned in the spec).
+
+## Phase 3: Verification
+
+- [x] 3.1 Run build or serve locally to verify there are no errors.
+- [x] 3.2 Visually confirm in the browser that the download button displays "Download Resume".
+
+## Phase 4: Delivery
+
+- [x] 4.1 Stage and commit `content.json` using conventional commits (e.g. `feat: change CV download button label to 'Resume'`).
+- [x] 4.2 Push branch and create a Pull Request against `main`.


### PR DESCRIPTION
Closes #21

## Summary
- Changed the download button label in the navbar from "Download CV" to "Download Resume" to align with international standards.
- Updated the `downloadCv` value in `content.json`.
- No HTML or script changes required.

## Changes
| File | Change |
|------|--------|
| `content.json` | Updated `nav.downloadCv` from "Download CV" to "Download Resume" |

## Test Plan
- [x] Build passes (`npm run build`)
- [x] Manual verification: rendered `dist/index.html` shows "Download Resume" in navbar
- [x] No placeholder left unreplaced

## Contributor Checklist
- [x] Linked issue (#21)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers