### PR TITLE
fix: flatten experience cards on mobile viewport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+/test-results
 
 # production
 /build

--- a/index.html
+++ b/index.html
@@ -166,6 +166,15 @@
       min-height: 100%;
     }
 
+    @media (max-width: 767px) {
+      .experience-card {
+        border-width: 0 !important;
+        border-radius: 0 !important;
+        box-shadow: none !important;
+        padding: 0 !important;
+      }
+    }
+
     @media print {
       @page {
         margin: 1.5cm;

--- a/openspec/changes/resolve-issue-23-worktree/apply-progress.md
+++ b/openspec/changes/resolve-issue-23-worktree/apply-progress.md
@@ -1,0 +1,36 @@
+# Apply Progress — resolve-issue-23-worktree
+
+## Metadata
+- Mode: Standard
+- Delivery strategy: ask-always
+- Workload mode: single PR (budget risk: Low)
+- Worktree: `/home/leandro/projects/my-site-issue-23`
+- Branch: `fix/hide-card-mobile`
+
+## Completed Tasks
+- [x] 1.1 Edit `index.html`: Locate the `<style>` block containing the `.experience-card` class definitions.
+- [x] 1.2 Edit `index.html`: Add a `@media (max-width: 767px)` rule targeting `.experience-card`.
+- [x] 1.3 Edit `index.html`: Inside the media query, set `border-width: 0 !important`, `border-radius: 0 !important`, `box-shadow: none !important`, and `padding: 0 !important` to ensure override of Tailwind CDN classes.
+- [x] 2.1 Create Playwright test file for experience card responsive behavior.
+- [x] 2.2 Add desktop test (>=768px) asserting card chrome is present.
+- [x] 2.3 Add mobile test (375px) asserting card chrome is flattened.
+- [x] 2.4 Add breakpoint boundary test (375px -> 768px) asserting chrome returns.
+- [x] 2.5 Execute `npx playwright test`.
+
+## Files Changed
+- `index.html` — added mobile media-query override for `.experience-card` with `!important` declarations.
+- `tests/experience-card.spec.js` — added Playwright tests covering desktop, mobile flattening, and resize boundary behavior.
+- `openspec/changes/resolve-issue-23-worktree/tasks.md` — marked all 8 tasks as completed.
+
+## Verification
+- Command: `npx playwright test tests/experience-card.spec.js`
+  - Result: ✅ 3 passed
+- Command: `npx playwright test`
+  - Result: ✅ 3 passed
+
+## Deviations
+- None — implementation follows spec/proposal behavior for mobile flattening and desktop preservation.
+
+## Remaining
+- No remaining apply tasks.
+- Ready for verify phase.

--- a/openspec/changes/resolve-issue-23-worktree/archive-report.md
+++ b/openspec/changes/resolve-issue-23-worktree/archive-report.md
@@ -1,0 +1,31 @@
+## Archive Report
+
+**Change**: resolve-issue-23-worktree
+**Status**: ARCHIVED
+**Date**: 2026-06-15
+
+### Summary
+Resolved GitHub issue #23 — hide card styles on mobile viewport. Added a `@media (max-width: 767px)` block flattening `.experience-card` chrome (border, border-radius, box-shadow, padding) below 768px, mirroring the existing print-flatten pattern. Added 5 Playwright tests covering all 6 spec scenarios.
+
+### Artifacts
+- Proposal: `openspec/changes/resolve-issue-23-worktree/proposal.md`
+- Spec (delta): `openspec/changes/resolve-issue-23-worktree/specs/mobile-card-flatten/spec.md`
+- Tasks: `openspec/changes/resolve-issue-23-worktree/tasks.md`
+- Apply progress: `openspec/changes/resolve-issue-23-worktree/apply-progress.md`
+- Verify report: `openspec/changes/resolve-issue-23-worktree/verify-report.md`
+
+### Spec Sync
+Delta applied to main spec: `openspec/specs/static-cv-page/spec.md`
+- Requirement "Experience Card Layout" updated with viewport-conditional chrome
+- Scenario "renders with all fields" → renamed to "renders with chrome on desktop"
+- Added 3 new scenarios: flattens on mobile, survives Tailwind CDN overrides, chrome returns at breakpoint boundary
+
+### Commits
+- `5b68f4b` — fix: flatten experience cards on mobile viewport
+- `2a5c962` — test: add coverage for current role highlight and multi-position grouping
+
+### Verification
+- Verdict: PASS
+- Tests: 5/5 passing
+- Scenarios: 6/6 compliant
+- Critical issues: 0

--- a/openspec/changes/resolve-issue-23-worktree/specs/mobile-card-flatten/spec.md
+++ b/openspec/changes/resolve-issue-23-worktree/specs/mobile-card-flatten/spec.md
@@ -1,0 +1,69 @@
+# Delta: Mobile Card Flattening (<768px)
+
+## MODIFIED Requirements
+
+### Requirement: Experience Card Layout
+
+The Experience section MUST use `.experience-card` class for each employment
+entry. Each card MUST contain: company name (`<h3>`), role (`<h4>`), period
+with `<time>` elements, and accomplishment items.
+
+At viewport widths **≥768px**, cards MUST use border (`border-outline-variant/40`),
+rounded corners (`rounded-lg`), and subtle shadow (`shadow-sm`).
+
+At viewport widths **<768px**, cards MUST flatten: computed `border-width` 0,
+`border-radius` 0, `box-shadow` none, and `padding` 0 — so mobile content renders
+with no card chrome. The flatten rule MUST take precedence over Tailwind CDN
+utilities.
+
+The current role MUST be marked with `.timeline-item-accent` class on its parent
+timeline item (blue dot indicator instead of gray). Multiple positions within the
+same company MUST be grouped in a single card with sub-sections separated by a
+top border (`border-t`).
+(Previously: cards mandated border/rounded/shadow unconditionally; no mobile-flatten behavior defined)
+
+#### Scenario: Experience card renders with chrome on desktop
+
+- GIVEN an experience entry at viewport width 1024px (≥768px)
+- WHEN it renders
+- THEN the card displays company name, role, period, and items
+- AND computed border-width is greater than 0
+- AND computed border-radius is greater than 0
+- AND computed box-shadow is not none
+- AND computed padding is greater than 0
+
+#### Scenario: Experience card flattens on mobile
+
+- GIVEN an experience entry at viewport width 375px (<768px)
+- WHEN the card renders after Tailwind CDN injection
+- THEN computed border-width is 0
+- AND computed border-radius is 0
+- AND computed box-shadow is none
+- AND computed padding is 0
+
+#### Scenario: Mobile flatten survives Tailwind CDN overrides
+
+- GIVEN the page is loaded at viewport width 375px
+- WHEN Tailwind CDN injects its utility styles
+- THEN the `.experience-card` flatten values still apply
+- AND no border, shadow, rounded corner, or padding is visible
+
+#### Scenario: Card chrome returns at breakpoint boundary
+
+- GIVEN an experience entry
+- WHEN the viewport is resized from 375px to exactly 768px
+- THEN the card regains border, rounded corners, shadow, and padding
+
+#### Scenario: Current role is highlighted
+
+- GIVEN the AXA Partners entry (current role)
+- WHEN it renders in the timeline
+- THEN its parent `.timeline-item` has the `.timeline-item-accent` class
+- AND the timeline dot marker is rendered in the accent color (#0051d5)
+
+#### Scenario: Multiple positions within same company
+
+- GIVEN the Devborn entry with multiple positions
+- WHEN it renders
+- THEN a single card contains both positions
+- AND positions are separated by a top border (`border-t`)

--- a/openspec/changes/resolve-issue-23-worktree/tasks.md
+++ b/openspec/changes/resolve-issue-23-worktree/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: resolve-issue-23-worktree
+
+## Review Workload Forecast
+
+Decision needed before apply: No
+Chained PRs recommended: No
+Chain strategy: stacked-to-main
+400-line budget risk: Low
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | CSS styling and E2E Tests | PR 1 | <100 lines total (CSS + Playwright) |
+
+## Phase 1: Core Implementation
+
+- [x] 1.1 Edit `index.html`: Locate the `<style>` block containing the `.experience-card` class definitions.
+- [x] 1.2 Edit `index.html`: Add a `@media (max-width: 767px)` rule targeting `.experience-card`.
+- [x] 1.3 Edit `index.html`: Inside the media query, set `border-width: 0 !important`, `border-radius: 0 !important`, `box-shadow: none !important`, and `padding: 0 !important` to ensure the override of Tailwind CDN classes.
+
+## Phase 2: Testing / Verification
+
+- [x] 2.1 Create Playwright test file (e.g., `tests/experience-card.spec.ts`) if it doesn't exist, or edit an existing relevant test suite.
+- [x] 2.2 Add Test: Verify "Experience card renders with chrome on desktop" (viewport width ≥768px) and asserts computed properties.
+- [x] 2.3 Add Test: Verify "Experience card flattens on mobile" (viewport width 375px) ensuring border 0, radius 0, shadow none, and padding 0.
+- [x] 2.4 Add Test: Verify "Card chrome returns at breakpoint boundary" (resize viewport from 375px to 768px and assert properties return).
+- [x] 2.5 Execute `npx playwright test` to verify changes align with the spec scenarios.

--- a/openspec/changes/resolve-issue-23-worktree/verify-report.md
+++ b/openspec/changes/resolve-issue-23-worktree/verify-report.md
@@ -1,0 +1,67 @@
+## Verification Report
+
+**Change**: resolve-issue-23-worktree
+**Version**: N/A
+**Mode**: Standard
+
+### Completeness
+| Metric | Value |
+|--------|-------|
+| Tasks total | 8 |
+| Tasks complete | 8 |
+| Tasks incomplete | 0 |
+
+### Build & Tests Execution
+**Build**: ✅ Passed (No separate build step required for static HTML/CSS)
+
+**Tests**: ✅ 5 passed / ❌ 0 failed / ⚠️ 0 skipped
+```text
+npx playwright test tests/experience-card.spec.js
+  ✓  1 tests/experience-card.spec.js:25:1 › Experience card renders with chrome on desktop (>=768px) (2.4s)
+  ✓  2 tests/experience-card.spec.js:36:1 › Experience card flattens on mobile (<768px) (4.7s)
+  ✓  3 tests/experience-card.spec.js:47:1 › Card chrome returns at breakpoint boundary after resize to 768px (2.4s)
+  ✓  4 tests/experience-card.spec.js:65:1 › Current role is highlighted (2.4s)
+  ✓  5 tests/experience-card.spec.js:76:1 › Multiple positions within same company are grouped (2.3s)
+
+  5 passed (14.6s)
+```
+
+**Coverage**: ➖ Not available
+
+### Spec Compliance Matrix
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| Experience Card Layout | Experience card renders with chrome on desktop | `tests/experience-card.spec.js` > `Experience card renders with chrome on desktop (>=768px)` | ✅ COMPLIANT |
+| Experience Card Layout | Experience card flattens on mobile | `tests/experience-card.spec.js` > `Experience card flattens on mobile (<768px)` | ✅ COMPLIANT |
+| Experience Card Layout | Mobile flatten survives Tailwind CDN overrides | `tests/experience-card.spec.js` > `Experience card flattens on mobile (<768px)` (implicit via 2s wait + `!important`) | ✅ COMPLIANT |
+| Experience Card Layout | Card chrome returns at breakpoint boundary | `tests/experience-card.spec.js` > `Card chrome returns at breakpoint boundary after resize to 768px` | ✅ COMPLIANT |
+| Experience Card Layout | Current role is highlighted | `tests/experience-card.spec.js` > `Current role is highlighted` | ✅ COMPLIANT |
+| Experience Card Layout | Multiple positions within same company | `tests/experience-card.spec.js` > `Multiple positions within same company are grouped` | ✅ COMPLIANT |
+
+**Compliance summary**: 6/6 scenarios compliant
+
+### Correctness (Static Evidence)
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Experience Card Layout | ✅ Implemented | CSS media query applied with `!important` to flatten cards below 768px |
+
+### Coherence (Design)
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| N/A | ✅ | No separate design artifact; CSS spec implemented as described in proposal |
+
+### Issues Found
+**CRITICAL**: None
+
+**WARNING**: None
+
+**SUGGESTION**:
+- "Mobile flatten survives Tailwind CDN overrides" relies on the implicit 2s wait in `test.beforeEach` for Tailwind CDN injection. An explicit assertion on Tailwind utility presence (e.g. waiting for `<style>` injection) would harden the test against timing flakiness.
+
+### Verdict
+PASS
+Implementation is correct and all 6 spec scenarios are covered by passing tests. Ready for archive and PR creation.
+
+### Commits
+- `5b68f4b` — `fix: flatten experience cards on mobile viewport`
+- `2a5c962` — `test: add coverage for current role highlight and multi-position grouping`

--- a/openspec/specs/static-cv-page/spec.md
+++ b/openspec/specs/static-cv-page/spec.md
@@ -200,14 +200,54 @@ The page MUST use a static content template system where all text, links, and me
 
 ### Requirement: Experience Card Layout
 
-The Experience section MUST use `.experience-card` class for each employment entry. Each card MUST contain: company name (`<h3>`), role (`<h4>`), period with `<time>` elements, and accomplishment items. Cards MUST use border (`border-outline-variant/40`), rounded corners (`rounded-lg`), and subtle shadow (`shadow-sm`). The current role MUST be marked with `.timeline-item-accent` class on its parent timeline item (blue dot indicator instead of gray). Multiple positions within the same company MUST be grouped in a single card with sub-sections separated by a top border (`border-t`).
+The Experience section MUST use `.experience-card` class for each employment
+entry. Each card MUST contain: company name (`<h3>`), role (`<h4>`), period
+with `<time>` elements, and accomplishment items.
 
-#### Scenario: Experience card renders with all fields
+At viewport widths **≥768px**, cards MUST use border (`border-outline-variant/40`),
+rounded corners (`rounded-lg`), and subtle shadow (`shadow-sm`).
 
-- GIVEN an experience entry
+At viewport widths **<768px**, cards MUST flatten: computed `border-width` 0,
+`border-radius` 0, `box-shadow` none, and `padding` 0 — so mobile content renders
+with no card chrome. The flatten rule MUST take precedence over Tailwind CDN
+utilities.
+
+The current role MUST be marked with `.timeline-item-accent` class on its parent
+timeline item (blue dot indicator instead of gray). Multiple positions within the
+same company MUST be grouped in a single card with sub-sections separated by a
+top border (`border-t`).
+
+#### Scenario: Experience card renders with chrome on desktop
+
+- GIVEN an experience entry at viewport width 1024px (≥768px)
 - WHEN it renders
 - THEN the card displays company name, role, period, and items
-- AND the card has border, rounded corners, and shadow
+- AND computed border-width is greater than 0
+- AND computed border-radius is greater than 0
+- AND computed box-shadow is not none
+- AND computed padding is greater than 0
+
+#### Scenario: Experience card flattens on mobile
+
+- GIVEN an experience entry at viewport width 375px (<768px)
+- WHEN the card renders after Tailwind CDN injection
+- THEN computed border-width is 0
+- AND computed border-radius is 0
+- AND computed box-shadow is none
+- AND computed padding is 0
+
+#### Scenario: Mobile flatten survives Tailwind CDN overrides
+
+- GIVEN the page is loaded at viewport width 375px
+- WHEN Tailwind CDN injects its utility styles
+- THEN the `.experience-card` flatten values still apply
+- AND no border, shadow, rounded corner, or padding is visible
+
+#### Scenario: Card chrome returns at breakpoint boundary
+
+- GIVEN an experience entry
+- WHEN the viewport is resized from 375px to exactly 768px
+- THEN the card regains border, rounded corners, shadow, and padding
 
 #### Scenario: Current role is highlighted
 

--- a/tests/experience-card.spec.js
+++ b/tests/experience-card.spec.js
@@ -61,3 +61,25 @@ test('Card chrome returns at breakpoint boundary after resize to 768px', async (
   expect(desktopStyles.boxShadow).not.toBe('none');
   expect(desktopStyles.paddingTop).toBeGreaterThan(0);
 });
+
+test('Current role is highlighted', async ({ page }) => {
+  const axaItem = page.locator('.timeline-item-accent').first();
+  await expect(axaItem).toBeVisible();
+  await expect(axaItem).toHaveClass(/timeline-item-accent/);
+
+  const dotColor = await axaItem.evaluate((el) => {
+    return window.getComputedStyle(el, '::before').backgroundColor;
+  });
+  expect(dotColor).toBe('rgb(0, 81, 213)');
+});
+
+test('Multiple positions within same company are grouped', async ({ page }) => {
+  const devbornCard = page.locator('.experience-card:has-text("Devborn")');
+  await expect(devbornCard).toBeVisible();
+
+  const positions = devbornCard.locator('h4');
+  await expect(positions).toHaveCount(2);
+
+  const separator = devbornCard.locator('.border-t');
+  await expect(separator).toBeVisible();
+});

--- a/tests/experience-card.spec.js
+++ b/tests/experience-card.spec.js
@@ -1,0 +1,63 @@
+const { test, expect } = require('playwright/test');
+
+const pageUrl = 'file:///home/leandro/projects/my-site-issue-23/index.html';
+
+async function getCardStyles(page) {
+  return page.locator('.experience-card').first().evaluate((element) => {
+    const computed = window.getComputedStyle(element);
+    const toNumber = (value) => Number.parseFloat(value || '0') || 0;
+
+    return {
+      borderTopWidth: toNumber(computed.borderTopWidth),
+      borderRadius: toNumber(computed.borderTopLeftRadius),
+      boxShadow: computed.boxShadow,
+      paddingTop: toNumber(computed.paddingTop),
+    };
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(pageUrl, { waitUntil: 'load' });
+  await page.waitForTimeout(2000);
+  await expect(page.locator('.experience-card').first()).toBeVisible();
+});
+
+test('Experience card renders with chrome on desktop (>=768px)', async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 900 });
+
+  const styles = await getCardStyles(page);
+
+  expect(styles.borderTopWidth).toBeGreaterThan(0);
+  expect(styles.borderRadius).toBeGreaterThan(0);
+  expect(styles.boxShadow).not.toBe('none');
+  expect(styles.paddingTop).toBeGreaterThan(0);
+});
+
+test('Experience card flattens on mobile (<768px)', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 });
+
+  const styles = await getCardStyles(page);
+
+  expect(styles.borderTopWidth).toBe(0);
+  expect(styles.borderRadius).toBe(0);
+  expect(styles.boxShadow).toBe('none');
+  expect(styles.paddingTop).toBe(0);
+});
+
+test('Card chrome returns at breakpoint boundary after resize to 768px', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 });
+  const mobileStyles = await getCardStyles(page);
+
+  expect(mobileStyles.borderTopWidth).toBe(0);
+  expect(mobileStyles.borderRadius).toBe(0);
+  expect(mobileStyles.boxShadow).toBe('none');
+  expect(mobileStyles.paddingTop).toBe(0);
+
+  await page.setViewportSize({ width: 768, height: 900 });
+  const desktopStyles = await getCardStyles(page);
+
+  expect(desktopStyles.borderTopWidth).toBeGreaterThan(0);
+  expect(desktopStyles.borderRadius).toBeGreaterThan(0);
+  expect(desktopStyles.boxShadow).not.toBe('none');
+  expect(desktopStyles.paddingTop).toBeGreaterThan(0);
+});


### PR DESCRIPTION
Closes #23

## What

The 5 `.experience-card` elements kept their Tailwind card chrome (`border ... rounded-lg shadow-sm p-5`) on mobile (<768px), looking cramped. This adds a `@media (max-width: 767px)` block that flattens the cards — no border, shadow, rounded corner, or padding — mirroring the existing print-flatten pattern.

## Changes

- `index.html`: new `@media (max-width: 767px)` block with `!important` overrides on `.experience-card` (border-width, border-radius, box-shadow, padding)
- `tests/experience-card.spec.js`: 5 Playwright tests covering all spec scenarios

## Tests

```
npx playwright test tests/experience-card.spec.js
  ✓  Experience card renders with chrome on desktop (>=768px)
  ✓  Experience card flattens on mobile (<768px)
  ✓  Card chrome returns at breakpoint boundary after resize to 768px
  ✓  Current role is highlighted
  ✓  Multiple positions within same company are grouped

  5 passed
```

## Approach

Mirrors the proven print-flatten rule (`index.html:254-266`) using `!important` to beat Tailwind CDN utilities. Rejected responsive Tailwind utility variants (`p-0 md:p-5`) — larger diff across 5 elements, diverges from the issue's stated fix, harder to keep consistent with the print rule.

## SDD Artifacts

Change tracked via SDD (openspec): `openspec/changes/resolve-issue-23-worktree/`
Spec synced to `openspec/specs/static-cv-page/spec.md`